### PR TITLE
Update active tab, instead of creating a new window

### DIFF
--- a/button/popup.js
+++ b/button/popup.js
@@ -117,8 +117,14 @@ var Sites = {
             if (checked) {
                 chrome.tabs.create({ url: url });
             } else {
-                chrome.windows.create({ url: url, focused: true });
-            }
+                chrome.tabs.query({ active: true }, function(tabs) {
+                    var tab = tabs[0];
+                    chrome.tabs.update(tab.id, { url: url });
+                    // Extension's popup doesn't automatically close,
+                    // so close it manually
+                    window.close();
+                });
+                }
         });
 
         // Remove button click event


### PR DESCRIPTION
Here’s a Trello [link](https://trello.com/c/2kmAamP3/20-open-in-new-tab-off-is-open-in-current-tab-not-new-window).
